### PR TITLE
Install bash completion script

### DIFF
--- a/ubuntu/debian/libignition-msgs-dev.install
+++ b/ubuntu/debian/libignition-msgs-dev.install
@@ -7,4 +7,4 @@ usr/lib/ruby/ignition/*.rb
 usr/lib/*/ruby/ignition/msgs[0-99]/*
 usr/lib/ruby/ignition/*.rb
 usr/share/ignition/ignition-msgs*/ignition-msgs[0-9].tag.xml
-usr/share/gz/gz1.completion.d/msgs5.bash_completion.sh
+usr/share/gz/gz1.completion.d/msgs[0-9].bash_completion.sh

--- a/ubuntu/debian/libignition-msgs-dev.install
+++ b/ubuntu/debian/libignition-msgs-dev.install
@@ -7,3 +7,4 @@ usr/lib/ruby/ignition/*.rb
 usr/lib/*/ruby/ignition/msgs[0-99]/*
 usr/lib/ruby/ignition/*.rb
 usr/share/ignition/ignition-msgs*/ignition-msgs[0-9].tag.xml
+usr/share/gz/gz1.completion.d/msgs5.bash_completion.sh


### PR DESCRIPTION
Trying to fix https://github.com/gazebosim/gz-msgs/pull/254#issuecomment-1188345183

I don't know what's the way to test this, as I've not done a release before.

The number after `gz` is the version of `gz-tools`. It is `1` for Citadel, but it will be different for Fortress, Garden, etc.
Does the number after `msgs` need to be a wildcard, or should it just be `5`, since this is the release repo for `gz-msgs5`?