### PR TITLE
Install cmdmsgs5.rb to a single package

### DIFF
--- a/ubuntu/debian/libignition-msgs-dev.install
+++ b/ubuntu/debian/libignition-msgs-dev.install
@@ -3,6 +3,5 @@ usr/lib/*/*.so
 usr/lib/*/pkgconfig/*.pc
 usr/lib/*/cmake/ignition-msgs*/*
 usr/share/ignition/*
-usr/lib/ruby/ignition/*.rb
 usr/lib/*/ruby/ignition/msgs[0-99]/*
 usr/share/ignition/ignition-msgs*/ignition-msgs[0-9].tag.xml

--- a/ubuntu/debian/libignition-msgs-dev.install
+++ b/ubuntu/debian/libignition-msgs-dev.install
@@ -2,6 +2,6 @@ usr/include/*
 usr/lib/*/*.so
 usr/lib/*/pkgconfig/*.pc
 usr/lib/*/cmake/ignition-msgs*/*
-usr/share/ignition/*
+usr/share/ignition/*/*.tag.xml
 usr/lib/*/ruby/ignition/msgs[0-99]/*
 usr/share/ignition/ignition-msgs*/ignition-msgs[0-9].tag.xml


### PR DESCRIPTION
* Follow up to https://github.com/gazebo-release/gz-msgs5-release/pull/4
* Part of https://github.com/gazebo-tooling/release-tools/issues/529

There was a duplicate entry, which is turning debbuilds yellow:

https://build.osrfoundation.org/job/ign-msgs5-debbuilder/201/consoleFull

```
W: ignition-msgs5 source: binaries-have-file-conflict libignition-msgs5 libignition-msgs5-dev usr/lib/ruby/ignition/cmdmsgs5.rb
W: ignition-msgs5 source: binaries-have-file-conflict libignition-msgs5 libignition-msgs5-dev usr/share/ignition/msgs5.yaml
```